### PR TITLE
Feat/other object fit strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ bagman.setup({
 
     -- whether to immediately start changing bg image every <interval> seconds on
     -- startup.
-    -- default: false
+    -- default: true
     start_looping = true,
 
     -- whether to change tab_bar colors based off the current background image

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ a `setup()` function though.
 bagman.setup({
     -- required
     -- pass in directories that contain images for bagman to search in
-    directories = {
+    dirs = {
         -- you can pass in directories as a string (must be absolute path),
         "/abs/path/to/dir",
 
@@ -51,9 +51,10 @@ bagman.setup({
             path = os.getenv("HOME") .. "/path/to/home/subdir",
             vertical_align = "Top", -- default: "Middle"
             horizontal_align = "Right", -- default: "Center"
+            object_fit = "Fill", -- default: "Contain"
         },
 
-        -- horizontal_align and vertical_align are optional.
+        -- all fields except path are optional
         -- this is equivalent to just passing it in as a string.
         {
             path = os.getenv("HOME") .. "/path/to/another/home/subdir",

--- a/plugin/bagman/cmd.lua
+++ b/plugin/bagman/cmd.lua
@@ -20,13 +20,12 @@ function M.exec(opts)
 	elseif M.platform_is("windows") then
 		command = opts.windows or {}
 	else
-		wezterm.log_error("Failed to execute command. Unknown OS:", wezterm.target_triple)
+		wezterm.log_error("BAGMAN CMD ERROR: Failed to execute command. Unknown OS:", wezterm.target_triple)
 		return nil
 	end
 	local success, stdout, stderr = wezterm.run_child_process(command)
 	if not success then
-		wezterm.log_error("Failed to execute command: ", table.concat(command, ""))
-		wezterm.log_error("error:", stderr)
+		wezterm.log_error("BAGMAN CMD ERROR: Failed to execute command: ", table.concat(command, ""), "error:", stderr)
 		return nil
 	end
 	return stdout
@@ -37,12 +36,12 @@ end
 function M.is_executable(opts)
 	if M.platform_is("linux") then
 		if not opts.linux then
-			wezterm.log_error("No command given for linux to execute")
+			wezterm.log_error("BAGMAN CMD ERROR: No command given for linux to execute")
 			return false
 		end
 		local handle = io.popen("which " .. opts.linux .. " 2>/dev/null")
 		if not handle then
-			wezterm.log_error("Failed to execute 'which'")
+			wezterm.log_error("BAGMAN CMD ERROR: Failed to execute 'which'")
 			return false
 		end
 		local result = handle:read("*a")
@@ -50,12 +49,12 @@ function M.is_executable(opts)
 		return result ~= opts.linux .. " not found"
 	elseif M.platform_is("apple") then
 		if not opts.macos then
-			wezterm.log_error("No command given for macos to execute")
+			wezterm.log_error("BAGMAN CMD ERROR: No command given for macos to execute")
 			return false
 		end
 		local handle = io.popen("which " .. opts.macos .. " 2>/dev/null")
 		if not handle then
-			wezterm.log_error("Failed to execute 'which'")
+			wezterm.log_error("BAGMAN CMD ERROR: Failed to execute 'which'")
 			return false
 		end
 		local result = handle:read("*a")
@@ -63,19 +62,19 @@ function M.is_executable(opts)
 		return result ~= opts.macos .. " not found"
 	elseif M.platform_is("windows") then
 		if not opts.windows then
-			wezterm.log_error("No command given for windows to execute")
+			wezterm.log_error("BAGMAN CMD ERROR: No command given for windows to execute")
 			return false
 		end
 		local handle = io.popen("where " .. opts.windows .. " 2>NUL")
 		if not handle then
-			wezterm.log_error("Failed to execute 'where'")
+			wezterm.log_error("BAGMAN CMD ERROR: Failed to execute 'where'")
 			return false
 		end
 		local result = handle:read("*a")
 		handle:close()
 		return result ~= ""
 	else
-		wezterm.log_error("Failed to execute command:", opts.windows, "; unknown OS")
+		wezterm.log_error("BAGMAN CMD ERROR: Failed to execute command:", opts.windows, "; unknown OS")
 		return false
 	end
 end

--- a/plugin/bagman/image-handler.lua
+++ b/plugin/bagman/image-handler.lua
@@ -75,9 +75,9 @@ end
 ---@return number height
 function M.contain_dimensions(image_width, image_height, window_width, window_height)
 	if image_width > image_height then
-		return window_width, window_width * math.floor(image_height / image_width)
+		return window_width, math.floor(window_width * image_height / image_width)
 	else
-		return math.floor(image_width / image_height) * window_height, window_height
+		return math.floor(window_height * image_width / image_height), window_height
 	end
 end
 
@@ -94,9 +94,9 @@ end
 ---@return number height
 function M.cover_dimensions(image_width, image_height, window_width, window_height)
 	if image_width > image_height then
-		return image_width * math.floor(window_height / image_height), window_height
+		return math.floor(window_height * image_width / image_height), window_height
 	else
-		return window_width, image_height * math.floor(window_width / image_width)
+		return window_width, math.floor(window_width * image_height / image_width)
 	end
 end
 

--- a/plugin/bagman/image-handler.lua
+++ b/plugin/bagman/image-handler.lua
@@ -40,29 +40,64 @@ function M.dimensions(image)
 	return width, height, true
 end
 
----Computes the `contain` width and height of an image using current window width and height as
----basis.
+---Returns the resized dimensions of an image based on the specified object_fit strategy
+---@param image_width number
+---@param image_height number
+---@param window_width number
+---@param window_height number
+---@param object_fit "Contain" | "Cover" | "Fill"
+---@return number new_width
+---@return number new_height
+function M.resize_image(image_width, image_height, window_width, window_height, object_fit)
+	if "Contain" == object_fit then
+		local new_width, new_height = M.contain_dimensions(image_width, image_height, window_width, window_height)
+		return new_width, new_height
+	elseif "Cover" == object_fit then
+		local new_width, new_height = M.cover_dimensions(image_width, image_height, window_width, window_height)
+		return new_width, new_height
+	elseif "Fill" == object_fit then
+		return window_width, window_height
+	else
+		wezterm.log_error("BAGMAN IMAGE HANDLER ERROR: unknown object_fit:", object_fit)
+		return image_width, image_height
+	end
+end
+
+---Computes css's `object-fit: contain` width and height of an image using current window width and
+---height as basis.
 ---Simulates css's `object-fit: contain` where the image keeps its aspect ratio, but is resized to
----fit within the given window dimensions. This is unlike `cover` where the image keeps its aspect
----ratio and fills the given dimension but will be clipped to fit
----@param width number width of image to scale
----@param height number height of image to scale
----@param windowWidth number width of current window
----@param windowHeight number height of current window
+---fit within the given window dimensions.
+---@param image_width number
+---@param image_height number
+---@param window_width number
+---@param window_height number
 ---@return number width
 ---@return number height
-function M.contain_dimensions(width, height, windowWidth, windowHeight)
-	local ratio = width / height
-	local width_val = 0
-	local height_val = 0
-	if ratio > 1 then
-		width_val = windowWidth
-		height_val = math.floor(windowWidth / ratio)
+function M.contain_dimensions(image_width, image_height, window_width, window_height)
+	if image_width > image_height then
+		return window_width, window_width * math.floor(image_height / image_width)
 	else
-		width_val = math.floor(ratio * windowHeight)
-		height_val = windowHeight
+		return math.floor(image_width / image_height) * window_height, window_height
 	end
-	return width_val, height_val
+end
+
+---Computes css's `object-fit: cover` width and height of an image using current window width and
+---height as basis.
+---This can already be done in wezterm by doing "Cover" on whichever dimension is smaller and nil
+---on the other. This is just implemented again to stay consisten with other object_fits working
+---with numbers
+---@param image_width number
+---@param image_height number
+---@param window_width number
+---@param window_height number
+---@return number width
+---@return number height
+function M.cover_dimensions(image_width, image_height, window_width, window_height)
+	if image_width > image_height then
+		return image_width * math.floor(window_height / image_height), window_height
+	else
+		return window_width, image_height * math.floor(window_width / image_width)
+	end
 end
 
 return M

--- a/plugin/bagman/image-handler.lua
+++ b/plugin/bagman/image-handler.lua
@@ -18,18 +18,23 @@ function M.dimensions(image)
 		return 0, 0, false
 	end
 	local res = cmd.exec({
-		linux = { "identify", "-format", "%w %h", image },
-		macos = { "magick", "identify", "-format", "%w %h", image },
-		windows = { "magick", "identify", "-format", "%w %h", image },
+		linux = { "identify", "-format", "%w %h ", image },
+		macos = { "magick", "identify", "-format", "%w %h ", image },
+		windows = { "magick", "identify", "-format", "%w %h ", image },
 	})
 	if not res then
-		wezterm.log_error("Failed to get dimensions of image:", image, "; Result is nil:", res)
+		wezterm.log_error(
+			"BAGMAN IMAGE HANDLER ERROR: Failed to get dimensions of image:",
+			image,
+			"; Result is nil:",
+			res
+		)
 		return 0, 0, false
 	end
-	local wh = res:match("^(%d+) (%d+)")
+	local wh = res:match("^(%d+) (%d+) ")
 	if not wh then
 		wezterm.log_error(
-			"Failed to get dimensions of image:",
+			"BAGMAN IMAGE HANDLER ERROR: Failed to get dimensions of image:",
 			image,
 			"; Did not get width and height from result:",
 			res

--- a/plugin/bagman/image-handler.lua
+++ b/plugin/bagman/image-handler.lua
@@ -37,7 +37,13 @@ function M.dimensions(image)
 		return 0, 0, false
 	end
 	local width, height = res:match("^(%d+) (%d+)")
-	return width, height, true
+	local width_num = tonumber(width)
+	local height_num = tonumber(height)
+	if not width_num or not height_num then
+		wezterm.log_error("BAGMAN IMAGE HANDLER ERROR: Failed to convert to number:", width, height)
+		return 0, 0, false
+	end
+	return width_num, height_num, true
 end
 
 ---Returns the resized dimensions of an image based on the specified object_fit strategy

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -26,7 +26,7 @@ local bagman_data = {
 		-- this manually by `wezterm.action.EmitEvent("bagman.start-loop")` or
 		-- `bagman.action.start_loop()`. Should only ever have 1 loop. If the event
 		-- `bagman.start_loop` gets emitted again, it won't do anything.
-		is_looping = false,
+		is_looping = true,
 		-- For limiting repeat triggering `bagman.next-image` event whenever an error is
 		-- encountered. Should only be incremented and reset in the 'bagman.next-image' event
 		-- handler.
@@ -207,6 +207,8 @@ function M.setup(opts)
 			local _, _, window = wezterm.mux.spawn_window(cmd or {})
 			loop_forever(window:gui_window())
 		end)
+	else
+		bagman_data.state.is_looping = false
 	end
 end
 

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -142,7 +142,7 @@ local function set_bg_image(window, image, image_width, image_height, vertical_a
 			source = {
 				Color = bagman_data.config.backdrop,
 			},
-			opacity = 0.90,
+			opacity = 0.95,
 			height = "100%",
 			width = "100%",
 		},
@@ -150,7 +150,7 @@ local function set_bg_image(window, image, image_width, image_height, vertical_a
 			source = {
 				File = image,
 			},
-			opacity = 0.20,
+			opacity = 0.10,
 			height = image_height,
 			width = image_width,
 			vertical_align = vertical_align,
@@ -308,13 +308,13 @@ wezterm.on("window-resized", function(window)
 	local overrides = window:get_config_overrides() or {}
 	local window_dims = window:get_dimensions()
 	local new_width, new_height = image_handler.contain_dimensions(
-		overrides.background[1].width, ---@diagnostic disable-line: undefined-field
-		overrides.background[1].height, ---@diagnostic disable-line: undefined-field
+		overrides.background[2].width, ---@diagnostic disable-line: undefined-field
+		overrides.background[2].height, ---@diagnostic disable-line: undefined-field
 		window_dims.pixel_width,
 		window_dims.pixel_height
 	)
-	overrides.background[1].width = new_width
-	overrides.background[1].height = new_height
+	overrides.background[2].width = new_width
+	overrides.background[2].height = new_height
 	window:set_config_overrides(overrides)
 end)
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -14,9 +14,14 @@ local function directory_exists(path)
 end
 
 local function get_require_path()
-	local path = "httpssCssZssZsgithubsDscomsZssaltkidsZsbagman"
-	local trailing_slash = path .. "sZs"
-	return directory_exists(trailing_slash) and trailing_slash or path
+	local url = "https://github.com/saltkid/bagman"
+	local path = url:gsub("[:/%.]", {
+		[":"] = "sCs",
+		["/"] = "sZs",
+		["."] = "sDs",
+	})
+	local with_trailing_slash = path .. "sZs"
+	return directory_exists(with_trailing_slash) and with_trailing_slash or path
 end
 
 package.path = package.path

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -23,12 +23,14 @@
 ---@field path string
 ---@field vertical_align? "Top" | "Middle" | "Bottom"
 ---@field horizontal_align? "Left" | "Center" | "Right"
+---@field object_fit? "Contain" | "Cover" | "Fill"
 
 ---An [BagmanDirtyDir] cleaned by setup()
 ---@class BagmanCleanDir config with assigned defaults
 ---@field path string
 ---@field vertical_align "Top" | "Middle" | "Bottom"
 ---@field horizontal_align "Left" | "Center" | "Right"
+---@field object_fit "Contain" | "Cover" | "Fill"
 
 ---Holds the local config and state of BGChanger
 ---@class BagmanData


### PR DESCRIPTION
closes #1 

---

# New
1. user can specify `object_fit` strategy per directory (`Contain`, `Cover`, `Fill`)

# Changes
- setup option `start_looping` to cycle bg images immediately is default true now
- rename setup option `directories` to `dirs`
- output from `identify` is converted to number
- getting require path uses string substitution for readability purposes

# Examples
1. `Contain`
```lua
local bagman = wezterm.plugin.require("https://github.com/saltkid/bagman")
bagman.setup({
  dirs = {
    {
      path = os.getenv("HOME") .. "/pictures/wt_bg/center-uniform-0.1",
      obect_fit = "Contain",
    },
    backdrop = "#181616",
  },
})
```
![image](https://github.com/user-attachments/assets/29380545-3229-4721-a1c5-983d39a79d27)
2. `Cover`
```lua
local bagman = wezterm.plugin.require("https://github.com/saltkid/bagman")
bagman.setup({
  dirs = {
    {
      path = os.getenv("HOME") .. "/pictures/wt_bg/center-uniform-0.1",
      obect_fit = "Cover",
    },
    backdrop = "#181616",
  },
})
```
![image](https://github.com/user-attachments/assets/a7b4f72e-0987-4c7a-a544-e0f8615580ab)
3. `Fill`
```lua
local bagman = wezterm.plugin.require("https://github.com/saltkid/bagman")
bagman.setup({
  dirs = {
    {
      path = os.getenv("HOME") .. "/pictures/wt_bg/center-uniform-0.1",
      obect_fit = "Fill",
    },
    backdrop = "#181616",
  },
})
```
![image](https://github.com/user-attachments/assets/2d282a12-f615-4430-a1f6-b1fbfadcc0ac)