### PR TITLE
Feat/set image event

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,32 @@ Alias for event format: `wezterm.action.EmitEvent("bagman.action-name")`
 | `stop_loop`  | `"bagman.stop-loop"` | stops the current auto cycle bg images loop |
 
 ## List of emitters
-Usage: `bagman.emit.emitter_name(win)` where `win` is a
-[Window object](https://wezfurlong.org/wezterm/config/lua/window/).
+Usage: `bagman.emit.emitter_name(window, ...opts)`
 
-Alias for event format: `wezterm.emit("bagman.emitter-name", win)`
-| action_name | alias for event | description |
-| ----------- | --------- | ----------- |
-| `next_image`  | `"bagman.next-image"` | changes the bg image |
-| `start_loop`  | `"bagman.start-loop"` | starts the auto cycle bg images loop at every user set interval (default: 30) |
-| `stop_loop`  | `"bagman.stop-loop"` | stops the current auto cycle bg images loop |
+Emitters always take a [Window object](https://wezfurlong.org/wezterm/config/lua/window/) with some
+having additional params.
+1. `next_image`
+    - changes the bg image with a random image
+    - alias for: `wezterm.emit("bagman.next-image", window)`
+2. `set_image`
+    - sets a specified image as the bg image 
+    - alias for: `wezterm.emit("bagman.set-image", window, "/path/to/image", {})`
+    - params:
+        - image (required): path to image file 
+        - opts: options to scale and position the image
+            ```lua
+            -- defaults
+            {
+                vertical_align = "Middle",
+                horizontal_align = "Center",
+                object_fit = "Contain",
+                width = --[[ the actual image width ]],
+                height = --[[ the actual image height ]],
+            }
+            ```
+3. `start_loop`
+    - alias for: `wezterm.emit("bagman.start-loop", window)`
+    - starts the auto cycle bg images loop at every user set interval
+4. `stop_loop`
+    - alias for: `wezterm.emit("bagman.stop-loop", window")`
+    - stops the current auto cycle bg images loop 

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -5,6 +5,19 @@ local colorscheme_builder = require("bagman.colorscheme-builder") --[[@as ColorS
 ---@class Bagman
 local M = {}
 
+-- OPTION DEFAULTS {{{
+-- defaults for various bagman data
+local default = {
+	interval = 30 * 60,
+	backdrop = "#000000",
+	change_tab_colors = false,
+	is_looping = true,
+	vertical_align = "Middle",
+	horizontal_align = "Center",
+	object_fit = "Contain",
+}
+---}}}
+
 -- STATE VARIABLES {{{
 
 ---Defaults
@@ -15,11 +28,11 @@ local bagman_data = {
 		-- vertical_align and horizontal_align that will be applied to each image found under it.
 		dirs = {},
 		-- Interval in seconds on when to trigger a background change.
-		interval = 30 * 60,
+		interval = default.interval,
 		-- Color Layer below the image. Affects the overall tint of the background due to the top
 		-- image's opacity.
-		backdrop = "#000000",
-		change_tab_colors = false,
+		backdrop = default.backdrop,
+		change_tab_colors = default.change_tab_colors,
 	},
 	state = {
 		-- Whether to immediately start changing bg image every <interval> seconds. You can trigger
@@ -182,24 +195,24 @@ function M.setup(opts)
 		if type(dirty_dir) == "string" then
 			clean_dirs[i] = {
 				path = dirty_dir,
-				vertical_align = "Middle",
-				horizontal_align = "Center",
-				object_fit = "Contain",
+				vertical_align = default.vertical_align,
+				horizontal_align = default.horizontal_align,
+				object_fit = default.object_fit,
 			}
 		else
 			clean_dirs[i] = {
 				path = dirty_dir.path,
-				vertical_align = dirty_dir.vertical_align or "Middle",
-				horizontal_align = dirty_dir.horizontal_align or "Center",
-				object_fit = dirty_dir.object_fit or "Contain",
+				vertical_align = dirty_dir.vertical_align or default.vertical_align,
+				horizontal_align = dirty_dir.horizontal_align or default.horizontal_align,
+				object_fit = dirty_dir.object_fit or default.object_fit,
 			}
 		end
 	end
 	bagman_data.config = {
 		dirs = clean_dirs,
-		interval = opts.interval or bagman_data.config.interval,
-		backdrop = opts.backdrop or bagman_data.config.backdrop,
-		change_tab_colors = opts.change_tab_colors or bagman_data.config.change_tab_colors,
+		interval = opts.interval or default.interval,
+		backdrop = opts.backdrop or default.backdrop,
+		change_tab_colors = opts.change_tab_colors or default.change_tab_colors,
 	}
 	if opts.loop_on_startup then
 		bagman_data.state.is_looping = true

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -42,3 +42,10 @@
 ---@class BagmanState
 ---@field is_looping boolean
 ---@field retries number
+
+---@class BagmanSetImageOptions
+---@field vertical_align? "Top" | "Middle" | "Bottom"
+---@field horizontal_align? "Left" | "Center" | "Right"
+---@field object_fit? "Contain" | "Cover" | "Fill"
+---@field width? number
+---@field height? number


### PR DESCRIPTION
closes #3 

---
# New
1. `"bagman.set-image"` event and `bagman.emit.set_image(window, image, opts)` to set specified image as the background image with options to scale and position it.
# Changes
- update actions and emitters docs
- put all defaults used by bagman into a `default` table (e.g. `default.interval`, `default.object_fit`)
   - not exported. only for internal use for now
# Example
set image temporarily on a bell event
```lua
local wezterm = require("wezterm")
local bagman = wezterm.plugin.require("https://github.com/saltkid/bagman")

wezterm.on("bell", function(window, pane)
    local overrides = window:get_config_overrides()
    -- background[1] is the backdrop color set by bagman
    -- background[2] is always the background image set by bagman
    local prev_image = overrides.background[2].source.File
    local jumpscare = "/path/to/some/image.png"
    bagman.emit.set_image(window, jumpscare, {
        object_fit = "Fill",
    })

    -- put back the previous image after 2 seconds
    wezterm.time.call_after(2, function()
        bagman.emit.set_image(window, prev_image)
    end)
end)
```
