### PR TITLE
Feat/images setup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ a `setup()` function though.
 # Sample Setup
 ```lua
 bagman.setup({
-    -- required
     -- pass in directories that contain images for bagman to search in
     dirs = {
         -- you can pass in directories as a string (must be absolute path),
@@ -55,9 +54,28 @@ bagman.setup({
         },
 
         -- all fields except path are optional
-        -- this is equivalent to just passing it in as a string.
+        -- below is equivalent to just passing it in as a string.
         {
             path = os.getenv("HOME") .. "/path/to/another/home/subdir",
+        },
+    },
+    -- you can also pass in image files
+    images = {
+        -- as string
+        "/abs/path/to/image",
+
+        -- as a table with options
+        {
+            path = os.getenv("HOME") .. "/path/to/another/image.jpg",
+            vertical_align = "Top", -- default: "Middle"
+            horizontal_align = "Right", -- default: "Center"
+            object_fit = "Fill", -- default: "Contain"
+        },
+
+        -- as a table without the options
+        -- below is equivalent to just passing it in as a string.
+        {
+            path = os.getenv("HOME") .. "/path/to/another/image.gif",
         },
     },
 

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -3,6 +3,7 @@
 ---Config from user passed to setup()
 ---@class BagmanSetupOptions
 ---@field dirs table<number, BagmanDirtyDir | string> list of directories that contain images
+---@field images table<number, BagmanDirtyImage | string> list of image files
 ---@field interval? number interval in seconds for changing the background
 ---@field backdrop? HexColor | AnsiColor bottom layer color to tint the image on top of it
 ---@field loop_on_startup? boolean whether to immediately start changing background every interval
@@ -13,7 +14,8 @@
 ---A [BagmanSetupOptions] with optional values filled in with defaults.
 ---Holds the local config needed to determine how to change the background
 ---@class BagmanConfig
----@field dirs table<number, BagmanCleanDir | string>
+---@field dirs table<number, BagmanCleanDir>
+---@field images table<number, BagmanCleanImage>
 ---@field interval number
 ---@field backdrop HexColor | AnsiColor
 ---@field change_tab_colors boolean whether to change tab bar colors based on the current background
@@ -27,6 +29,20 @@
 
 ---An [BagmanDirtyDir] cleaned by setup()
 ---@class BagmanCleanDir config with assigned defaults
+---@field path string
+---@field vertical_align "Top" | "Middle" | "Bottom"
+---@field horizontal_align "Left" | "Center" | "Right"
+---@field object_fit "Contain" | "Cover" | "Fill"
+
+---an image file object in images passed in setup()
+---@class BagmanDirtyImage
+---@field path string
+---@field vertical_align? "Top" | "Middle" | "Bottom"
+---@field horizontal_align? "Left" | "Center" | "Right"
+---@field object_fit? "Contain" | "Cover" | "Fill"
+
+---An [BagmanDirtyImage] cleaned by setup()
+---@class BagmanCleanImage config with assigned defaults
 ---@field path string
 ---@field vertical_align "Top" | "Middle" | "Bottom"
 ---@field horizontal_align "Left" | "Center" | "Right"


### PR DESCRIPTION
closes #2 

---

# New
1. allow user to pass in individual images during setup
# Changes
- empty `dirs` setup option is an ok state now.
  - you can pass in images to choose from so even if there are no dirs, as long as there are images to choose from, bagman should continue
  - only fail if both images and dirs are empty
- empty `images` setup option like above is an ok state too (as long as `dirs` is not empty)
# Example
```lua
bagman.setup({
    images = {
        -- as string
        "/abs/path/to/image.png",
        os.getenv("HOME") .. "/path/to/another/image.jpg",

        -- as table with options to scale and position the image
        {
            path = os.getenv("HOME") .. "/path/to/some/other/image.jpg",
            vertical_align = "Top", -- default: "Middle"
            horizontal_align = "Right", -- default: "Center"
            object_fit = "Fill", -- default: "Contain"
        },
    },
    -- can leave out `dirs` or keep it empty
    dirs = {},
})
```