### PR TITLE
Feat/add more setup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ return config
 ## Table of Contents
 - [`apply_to_config(config)`](#bagmanapply_to_configconfig)
 - [`setup(opts)`](#bagmansetupopts)
+- [`current_image()`](#bagmancurrent_image)
 - [`action.next_image()`](#bagmanactionnext_image)
 - [`action.start_loop()`](#bagmanactionstart_loop)
 - [`action.stop_loop()`](#bagmanactionstop_loop)
@@ -55,6 +56,8 @@ return config
 bagman only registers event listeners so `bagman.apply_to_config(config)` does
 nothing for now.
 ### `bagman.setup(opts)`
+To see all possible values for the fields of `dirs` and `images` entries,
+please see the [current_image](#bagmancurrent_image) section.
 ```lua
 bagman.setup({
     -- pass in directories that contain images for bagman to search in

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ bagman.setup({
             path = os.getenv("HOME") .. "/path/to/home/subdir",
             vertical_align = "Top", -- default: "Middle"
             horizontal_align = "Right", -- default: "Center"
+            opacity = 0.1, -- default: 1.0
+            hsb = { 
+                hue = 1.0, -- default: 1.0
+                saturation = 1.0, -- default: 1.0
+                brightness = 1.0, -- default: 1.0
+            }, 
             object_fit = "Fill", -- default: "Contain"
         },
 
@@ -82,12 +88,11 @@ bagman.setup({
         -- as string
         "/abs/path/to/image",
 
-        -- as a table with options
+        -- as a table with some options
         {
             path = os.getenv("HOME") .. "/path/to/another/image.jpg",
-            vertical_align = "Top", -- default: "Middle"
-            horizontal_align = "Right", -- default: "Center"
-            object_fit = "Fill", -- default: "Contain"
+            vertical_align = "Bottom", -- default: "Middle"
+            object_fit = "ScaleDown", -- default: "Contain"
         },
 
         -- as a table without the options
@@ -123,15 +128,30 @@ that this is readonly and even if the return value's fields are reassigned, it
 will not affect any bagman functionality.
 
 Fields:
-1. `width`: current width of the image as a background layer (not the original
-width)
-2. `height`: current width of the image as a background layer (not the original
-height)
-3. `path`: path to image file
-4. `object_fit`: current object fit used by the background image
-5. `vertical_align`: current vertical alignment used by the background image
-6. `horizontal_align`: current horizontal alignment used by the background
-image 
+1. `height`
+    - height of the image in px
+2. `horizontal_align`
+    - valid values: `"Left"`, `"Center"`, `"Middle"`
+    - same as wezterm's
+3. `hsb`
+    - fields: `hue`, `saturation`, `brightness`
+    - valid values for fields: from `0.0` above
+    - same as wezterm's
+4. `object_fit`
+    - how the image should be resized to fit the window
+    - valid values: `"Contain"`, `"Cover"`, `"Fill"`, `"None"`, `"ScaleDown"`
+    - these behave the same as css's
+    [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
+5. `opacity` 
+    - valid values: from `0.0` to `1.0`
+    - same as wezterm's
+6. `path`
+    - absolute path to image file
+7. `vertical_align`
+    - valid values: `"Top"`, `"Middle"`, `"Bottom"`
+    - same as wezterm's
+8. `width`
+    - width of the image in px
 
 ### `bagman.action.next_image()`
 _Alias for: `wezterm.action.EmitEvent("bagman.next-image")`_

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ bagman.setup({
                 brightness = 1.0, -- default: 1.0
             }, 
             object_fit = "Fill", -- default: "Contain"
+            scale = 0.5, -- default: 1.0
         },
 
         -- all fields except path are optional.
@@ -147,10 +148,15 @@ Fields:
     - same as wezterm's
 6. `path`
     - absolute path to image file
-7. `vertical_align`
+7. `scale`
+    - scale multiplier applied to image after the scaling done by `object_fit`.
+    For example, `object_fit = "Contain", scale = 0.5` will first scale the
+    image to fit within the window, then scale it down to 50% of that.
+    - valid values: from `0.0` above
+8. `vertical_align`
     - valid values: `"Top"`, `"Middle"`, `"Bottom"`
     - same as wezterm's
-8. `width`
+9. `width`
     - width of the image in px
 
 ### `bagman.action.next_image()`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # bagman
 Background Manager for [Wezterm](https://github.com/wez/wezterm/) that
 automatically cycles through different backgrounds at a user-defined interval.
-Usually, the interrupts to change background are quick but it might get too long
-if the image is too large.
+It handles configuring the `background` config option and will overwrite any
+previous values. Usually, the interrupts to change background are quick but it
+might get too long if the image is too large.
 
 ## Key Features
 - auto cycle background images at a user-defined interval.
@@ -109,11 +110,13 @@ bagman.setup({
     -- default: 30 * 60
     interval = 10 * 60,
 
-    -- Color Layer below the image. Affects the overall tint of the background
-    -- can be any ansi color like "Maroon", "Green", or "Aqua" or any hex color
-    -- string like "#121212"
-    -- default: "#000000"
-    backdrop = "#161616",
+    -- Color Layer below the image. Affects the overall tint of the image and
+    -- can be any ansi color like "Maroon", "Green", or "Aqua", any hex color
+    -- string like "#121212". 
+    -- It can also be a table specifying the color as ansi or hex string,
+    -- and the opacity as a number from 0.0 to 1.0
+    -- default: { color = "#000000", opacity = 1.0 }
+    backdrop = "#161616", -- equivalent to { color = "#161616", opacity = 1.0 }
 
     -- Whether to immediately start changing bg image every <interval> seconds
     -- on startup.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bagman.setup({
         "/abs/path/to/dir",
 
         -- or you can pass it in as a table where you can define options for
-        -- images under that directory.
+        -- images under that directory. Here are all the available options:
         {
             path = os.getenv("HOME") .. "/path/to/home/subdir",
             vertical_align = "Top", -- default: "Middle"
@@ -230,11 +230,13 @@ options to scale and position the image however you'd like. Specifically, the
 options are as follows:
 | option | default value |
 |--------|---------------|
-| `vertical_align` | `"Middle"` |
-| `horizontal_align` | `"Center"` |
-| `object_fit` | `"Contain"` |
-| `width` | `nil` |
 | `height` | `nil` |
+| `horizontal_align` | `"Center"` |
+| `hsb` | `{ hue = 1.0, saturation = 1.0, brightness = 1.0 }` |
+| `object_fit` | `"Contain"` |
+| `opacity` | `1.0` |
+| `vertical_align` | `"Middle"` |
+| `width` | `nil` |
 
 Note that if no width and height is given, the image will be scaled according
 to the `object_fit` option. Same goes for when only either width or height is

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ bagman.setup({
     -- Whether to immediately start changing bg image every <interval> seconds
     -- on startup.
     -- default: true
-    start_looping = true,
+    auto_cycle = true,
 
     -- whether to change tab_bar colors based off the current background image
     -- default: false
@@ -156,12 +156,12 @@ _Alias for: `wezterm.action.EmitEvent("bagman.start-loop")`_
 
 Starts the auto cycle bg images loop at every user set interval. Only one loop
 may be present so triggering this event again will safely do nothing. If
-`start_looping` setup option is set to true, triggering this action will not do
-anything since `start_looping = true` will create an image cycling loop on
+`auto_cycle` setup option is set to true, triggering this action will not do
+anything since `auto_cycle = true` will create an image cycling loop on
 startup.
 ```lua
 bagman.setup({
-    start_looping = true, -- will start the image cycle loop on startup
+    auto_cycle = true, -- will start the image cycle loop on startup
     dirs = { ... },
     ...
 })
@@ -240,12 +240,12 @@ _Alias for: `wezterm.emit("bagman.start-loop", window)`_
 
 Starts the auto cycle bg images loop at every user set interval. Only one loop
 may be present so manually emitting this event again will safely do nothing. If
-`start_looping` setup option is set to true, triggering this action will not do
-anything since `start_looping = true` will create an image cycling loop on
+`auto_cycle` setup option is set to true, triggering this action will not do
+anything since `auto_cycle = true` will create an image cycling loop on
 startup.
 ```lua
 bagman.setup({
-    start_looping = true, -- will start the image cycle loop on startup
+    auto_cycle = true, -- will start the image cycle loop on startup
     dirs = { ... },
     ...
 })

--- a/plugin/bagman/image-resizer.lua
+++ b/plugin/bagman/image-resizer.lua
@@ -46,11 +46,10 @@ end
 ---@return number width
 ---@return number height
 function M.contain_dimensions(image_width, image_height, window_width, window_height)
-	if image_width > image_height then
-		return window_width, math.floor(window_width * image_height / image_width)
-	else
-		return math.floor(window_height * image_width / image_height), window_height
-	end
+	local scale_width = window_width / image_width
+	local scale_height = window_height / image_height
+	local scale = math.min(scale_width, scale_height)
+	return math.floor(image_width * scale), math.floor(image_height * scale)
 end
 
 ---Computes css's `object-fit: cover` width and height of an image using current window width and
@@ -65,11 +64,10 @@ end
 ---@return number width
 ---@return number height
 function M.cover_dimensions(image_width, image_height, window_width, window_height)
-	if image_width > image_height then
-		return math.floor(window_height * image_width / image_height), window_height
-	else
-		return window_width, math.floor(window_width * image_height / image_width)
-	end
+	local scale_width = window_width / image_width
+	local scale_height = window_height / image_height
+	local scale = math.max(scale_width, scale_height)
+	return math.floor(image_width * scale), math.floor(image_height * scale)
 end
 
 return M

--- a/plugin/bagman/image-resizer.lua
+++ b/plugin/bagman/image-resizer.lua
@@ -8,7 +8,7 @@ local M = {}
 ---@param image_height number
 ---@param window_width number
 ---@param window_height number
----@param object_fit "Contain" | "Cover" | "Fill"
+---@param object_fit object_fit_opts
 ---@return number new_width
 ---@return number new_height
 function M.resize(image_width, image_height, window_width, window_height, object_fit)
@@ -20,6 +20,15 @@ function M.resize(image_width, image_height, window_width, window_height, object
 		return new_width, new_height
 	elseif "Fill" == object_fit then
 		return window_width, window_height
+	elseif "None" == object_fit then
+		return image_width, image_height
+	elseif "ScaleDown" == object_fit then
+		if image_width > window_width or image_height > window_height then
+			local new_width, new_height = M.contain_dimensions(image_width, image_height, window_width, window_height)
+			return new_width, new_height
+		else
+			return image_width, image_height
+		end
 	else
 		wezterm.log_error("BAGMAN IMAGE HANDLER ERROR: unknown object_fit:", object_fit)
 		return image_width, image_height

--- a/plugin/bagman/image-resizer.lua
+++ b/plugin/bagman/image-resizer.lua
@@ -8,7 +8,7 @@ local M = {}
 ---@param image_height number
 ---@param window_width number
 ---@param window_height number
----@param object_fit object_fit_opts
+---@param object_fit ObjectFit
 ---@return number new_width
 ---@return number new_height
 function M.resize(image_width, image_height, window_width, window_height, object_fit)

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -10,7 +10,7 @@ local M = {}
 -- defaults for various bagman data
 local default = {
 	auto_cycle = true,
-	backdrop = "#000000",
+	backdrop = { color = "#000000", opacity = 1.0 },
 	change_tab_colors = false,
 	horizontal_align = "Center",
 	hsb = { hue = 1.0, saturation = 1.0, brightness = 1.0 },
@@ -212,9 +212,9 @@ local function set_bg_image(
 	overrides.background = {
 		{
 			source = {
-				Color = bagman_data.config.backdrop,
+				Color = bagman_data.config.backdrop.color,
 			},
-			opacity = 0.95,
+			opacity = bagman_data.config.backdrop.opacity,
 			height = "100%",
 			width = "100%",
 		},
@@ -259,9 +259,10 @@ function M.setup(opts)
 	if (not opts.dirs or #opts.dirs == 0) and (not opts.images or #opts.images == 0) then
 		wezterm.log_error("BAGMAN ERROR: No directories and images provided for background images. args: ", opts)
 	end
-	-- clean dirs option
+
+	---@type table<number, BagmanCleanDir>
+	local clean_dirs = {}
 	opts.dirs = opts.dirs or {}
-	local clean_dirs = {} ---@type table<number, BagmanCleanDir>
 	for i = 1, #opts.dirs do
 		local dirty_dir = opts.dirs[i]
 		if type(dirty_dir) == "nil" then
@@ -288,9 +289,10 @@ function M.setup(opts)
 			}
 		end
 	end
-	-- clean images option
+
+	---@type table<number, BagmanCleanImage>
+	local clean_images = {}
 	opts.images = opts.images or {}
-	local clean_images = {} ---@type table<number, BagmanCleanImage>
 	for i = 1, #opts.images do
 		local dirty_image = opts.images[i]
 		if type(dirty_image) == "nil" then
@@ -317,13 +319,29 @@ function M.setup(opts)
 			}
 		end
 	end
+
+	---@type Backdrop
+	local clean_backdrop
+	if type(opts.backdrop) == "nil" then
+		clean_backdrop = default.backdrop
+	elseif type(opts.backdrop) == "string" then
+		clean_backdrop = {
+			color = opts.backdrop --[[@as string]],
+			opacity = default.backdrop.opacity,
+		}
+	else
+		clean_backdrop = {
+			color = opts.backdrop.color or default.backdrop.color,
+			opacity = opts.backdrop.opacity or default.backdrop.opacity,
+		}
+	end
 	-- setup config data with cleaned data
 	bagman_data.config = {
+		backdrop = clean_backdrop,
+		change_tab_colors = opts.change_tab_colors or default.change_tab_colors,
 		dirs = clean_dirs,
 		images = clean_images,
 		interval = opts.interval or default.interval,
-		backdrop = opts.backdrop or default.backdrop,
-		change_tab_colors = opts.change_tab_colors or default.change_tab_colors,
 	}
 	if opts.auto_cycle then
 		bagman_data.state.auto_cycle = true

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -219,7 +219,7 @@ end
 -- EXPORTED MEMBERS {{{
 
 -- Changes background image based on passed in configuration.
--- If `loop_on_startup` is true, this will create an event handler during [gui-startup](https://wezfurlong.org/wezterm/config/lua/gui-events/gui-startup.html).
+-- If `auto_cycle` is true, this will create an event handler during [gui-startup](https://wezfurlong.org/wezterm/config/lua/gui-events/gui-startup.html).
 -- If `change_tab_colors` is true, this will change `tab_bar` colors based off of the current image.
 ---@param opts BagmanSetupOptions
 function M.setup(opts)
@@ -280,7 +280,7 @@ function M.setup(opts)
 		backdrop = opts.backdrop or default.backdrop,
 		change_tab_colors = opts.change_tab_colors or default.change_tab_colors,
 	}
-	if opts.loop_on_startup then
+	if opts.auto_cycle then
 		bagman_data.state.is_looping = true
 		wezterm.on("gui-startup", function(cmd)
 			local _, _, window = wezterm.mux.spawn_window(cmd or {})

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -17,6 +17,7 @@ local default = {
 	interval = 30 * 60,
 	object_fit = "Contain",
 	opacity = 1.0,
+	scale = 1.0,
 	vertical_align = "Middle",
 }
 ---}}}
@@ -58,6 +59,7 @@ local bagman_data = {
 			object_fit = default.object_fit,
 			opacity = default.opacity,
 			path = "",
+			scale = default.scale,
 			vertical_align = default.vertical_align,
 			width = 0,
 		},
@@ -120,6 +122,7 @@ end
 ---@return f32 opacity
 ---@return Hsb hsb
 ---@return ObjectFit object_fit
+---@return f32 scale
 ---@return boolean ok successful execution
 local function random_image_from_dirs(dirs, more_images)
 	---@type table<number, string | BagmanCleanImage>
@@ -139,6 +142,7 @@ local function random_image_from_dirs(dirs, more_images)
 			default.opacity,
 			default.hsb,
 			default.object_fit,
+			default.scale,
 			false
 	end
 
@@ -149,6 +153,7 @@ local function random_image_from_dirs(dirs, more_images)
 		image.opacity or dir.opacity or default.opacity,
 		image.hsb or dir.hsb or default.hsb,
 		image.object_fit or dir.object_fit or default.object_fit,
+		image.scale or dir.scale or default.scale,
 		true
 end
 
@@ -178,9 +183,10 @@ end
 ---@param image_height number
 ---@param vertical_align string
 ---@param horizontal_align string
----@param object_fit string for keeping track of object_fit state between window resizes
----@param hsb Hsb,
 ---@param opacity f32
+---@param hsb Hsb,
+---@param object_fit string for keeping track of object_fit state between window resizes
+---@param scale f32
 ---@param colors? Palette tab line colorscheme
 local function set_bg_image(
 	window,
@@ -192,6 +198,7 @@ local function set_bg_image(
 	opacity,
 	hsb,
 	object_fit,
+	scale,
 	colors
 )
 	local overrides = window:get_config_overrides() or {}
@@ -210,8 +217,8 @@ local function set_bg_image(
 				File = image,
 			},
 			opacity = opacity,
-			height = image_height,
-			width = image_width,
+			height = image_height * scale,
+			width = image_width * scale,
 			vertical_align = vertical_align,
 			horizontal_align = horizontal_align,
 			hsb = hsb,
@@ -228,6 +235,7 @@ local function set_bg_image(
 		object_fit = object_fit,
 		opacity = opacity,
 		path = image,
+		scale = scale,
 		vertical_align = vertical_align,
 		width = image_width,
 	}
@@ -259,6 +267,7 @@ function M.setup(opts)
 				object_fit = default.object_fit,
 				opacity = default.opacity,
 				path = dirty_dir,
+				scale = default.scale,
 				vertical_align = default.vertical_align,
 			}
 		else
@@ -268,6 +277,7 @@ function M.setup(opts)
 				object_fit = dirty_dir.object_fit or default.object_fit,
 				opacity = dirty_dir.opacity or default.opacity,
 				path = dirty_dir.path,
+				scale = dirty_dir.scale or default.scale,
 				vertical_align = dirty_dir.vertical_align or default.vertical_align,
 			}
 		end
@@ -286,6 +296,7 @@ function M.setup(opts)
 				object_fit = default.object_fit,
 				opacity = default.opacity,
 				path = dirty_image,
+				scale = default.scale,
 				vertical_align = default.vertical_align,
 			}
 		else
@@ -295,6 +306,7 @@ function M.setup(opts)
 				object_fit = dirty_image.object_fit or default.object_fit,
 				opacity = dirty_image.opacity or default.opacity,
 				path = dirty_image.path,
+				scale = dirty_image.scale or default.scale,
 				vertical_align = dirty_image.vertical_align or default.vertical_align,
 			}
 		end
@@ -399,7 +411,7 @@ wezterm.on("bagman.next-image", function(window)
 		return
 	end
 
-	local image, vertical_align, horizontal_align, opacity, hsb, object_fit, ok =
+	local image, vertical_align, horizontal_align, opacity, hsb, object_fit, scale, ok =
 		random_image_from_dirs(bagman_data.config.dirs, bagman_data.config.images)
 	if not ok then
 		bagman_data.state.retries = bagman_data.state.retries + 1
@@ -433,6 +445,7 @@ wezterm.on("bagman.next-image", function(window)
 		opacity,
 		hsb,
 		object_fit,
+		scale,
 		colors
 	)
 	bagman_data.state.retries = 0
@@ -449,6 +462,7 @@ wezterm.on("bagman.set-image", function(window, image, opts)
 	opts.object_fit = opts.object_fit or default.object_fit
 	opts.opacity = opts.opacity or default.opacity
 	opts.vertical_align = opts.vertical_align or default.vertical_align
+	opts.scale = opts.scale or default.scale
 
 	if not opts.width or not opts.height then
 		local image_width, image_height, err = image_size.size(image)
@@ -484,6 +498,7 @@ wezterm.on("bagman.set-image", function(window, image, opts)
 		opts.opacity,
 		opts.hsb,
 		opts.object_fit,
+		opts.scale,
 		colors
 	)
 	bagman_data.state.retries = 0

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -111,9 +111,9 @@ end
 ---@param dirs table<number, BagmanCleanDir> to get random images from a random dir in dirs
 ---@param more_images table<number, BagmanCleanImage> additional images to choose from
 ---@return string image path to image file
----@return "Top" | "Middle" | "Bottom" vertical_align
----@return "Left" | "Center" | "Right" horizontal_align
----@return "Contain" | "Cover" | "Fill" object_fit
+---@return vertical_align_opts vertical_align
+---@return horizontal_align_opts horizontal_align
+---@return object_fit_opts object_fit
 ---@return boolean ok successful execution
 local function random_image_from_dirs(dirs, more_images)
 	---@type table<number, string | BagmanCleanImage>
@@ -141,14 +141,14 @@ end
 ---@param image string | BagmanCleanImage
 ---@param window_width number window's width in px (`window:get_dimensions().pixel_width`)
 ---@param window_height number window's height in px (`window:get_dimensions().pixel_height`)
----@param object_fit "Contain" | "Cover" | "Fill"
+---@param object_fit object_fit_opts
 ---@return number width image width
 ---@return number height image height
 ---@return bool ok successful execution
 local function scale_image(image, window_width, window_height, object_fit)
 	local image_width, image_height, err = image_size.size(image.path or image)
 	if err then
-		wezterm.log_info(err)
+		wezterm.log_error("BAGMAN ERROR:", err)
 		return 0, 0, false
 	end
 
@@ -413,7 +413,7 @@ wezterm.on("bagman.set-image", function(window, image, opts)
 	if not opts.width or not opts.height then
 		local image_width, image_height, err = image_size.size(image)
 		if err then
-			wezterm.log_info(err)
+			wezterm.log_error("BAGMAN ERROR:", err)
 			return
 		end
 		local window_dims = window:get_dimensions()
@@ -461,8 +461,6 @@ wezterm.on("window-resized", function(window)
 	)
 	overrides.background[2].width = new_width
 	overrides.background[2].height = new_height
-	bagman_data.state.current_image.width = new_width
-	bagman_data.state.current_image.height = new_height
 	window:set_config_overrides(overrides)
 end)
 

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -516,8 +516,8 @@ wezterm.on("window-resized", function(window)
 		window_dims.pixel_height,
 		bagman_data.state.current_image.object_fit
 	)
-	overrides.background[2].width = new_width
-	overrides.background[2].height = new_height
+	overrides.background[2].width = new_width * bagman_data.state.current_image.scale
+	overrides.background[2].height = new_height * bagman_data.state.current_image.scale
 	window:set_config_overrides(overrides)
 end)
 

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -6,13 +6,15 @@
 ---@alias HorizontalAlign "Left" | "Center" | "Right"
 ---@alias ObjectFit "Contain" | "Cover" | "Fill" | "None" | "ScaleDown"
 ---@alias Hsb { hue: f32, saturation: f32, brightness: f32 }
+---@alias Backdrop  { color: HexColor | AnsiColor, opacity: f32 }
+
 -- }}}
 
 ---Config from user passed to setup()
 ---@class BagmanSetupOptions
 ---@field auto_cycle? boolean whether to immediately start changing background every interval
 ---seconds on startup
----@field backdrop? HexColor | AnsiColor bottom layer color to tint the image on top of it
+---@field backdrop? Backdrop | HexColor | AnsiColor
 ---@field dirs table<number, BagmanDirtyDir | string> list of directories that contain images
 ---@field change_tab_colors? boolean whether to change tab bar colors based on the current background
 ---image
@@ -22,7 +24,7 @@
 ---A [BagmanSetupOptions] with optional values filled in with defaults.
 ---Holds the local config needed to determine how to change the background
 ---@class BagmanConfig
----@field backdrop HexColor | AnsiColor
+---@field backdrop Backdrop
 ---@field change_tab_colors boolean whether to change tab bar colors based on the current background
 ---@field dirs table<number, BagmanCleanDir>
 ---@field images table<number, BagmanCleanImage>

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -1,60 +1,68 @@
 ---@meta
 
+-- ALIASES {{{
+
+---@alias VerticalAlign "Top" | "Middle" | "Bottom"
+---@alias HorizontalAlign "Left" | "Center" | "Right"
+---@alias ObjectFit "Contain" | "Cover" | "Fill" | "None" | "ScaleDown"
+---@alias Hsb { hue: f32, saturation: f32, brightness: f32 }
+-- }}}
+
 ---Config from user passed to setup()
 ---@class BagmanSetupOptions
----@field dirs table<number, BagmanDirtyDir | string> list of directories that contain images
----@field images table<number, BagmanDirtyImage | string> list of image files
----@field interval? number interval in seconds for changing the background
----@field backdrop? HexColor | AnsiColor bottom layer color to tint the image on top of it
 ---@field auto_cycle? boolean whether to immediately start changing background every interval
 ---seconds on startup
+---@field backdrop? HexColor | AnsiColor bottom layer color to tint the image on top of it
+---@field dirs table<number, BagmanDirtyDir | string> list of directories that contain images
 ---@field change_tab_colors? boolean whether to change tab bar colors based on the current background
 ---image
+---@field images table<number, BagmanDirtyImage | string> list of image files
+---@field interval? number interval in seconds for changing the background
 
 ---A [BagmanSetupOptions] with optional values filled in with defaults.
 ---Holds the local config needed to determine how to change the background
 ---@class BagmanConfig
+---@field backdrop HexColor | AnsiColor
+---@field change_tab_colors boolean whether to change tab bar colors based on the current background
 ---@field dirs table<number, BagmanCleanDir>
 ---@field images table<number, BagmanCleanImage>
 ---@field interval number
----@field backdrop HexColor | AnsiColor
----@field change_tab_colors boolean whether to change tab bar colors based on the current background
-
--- GENERAL OPTIONS {{{
-
----@alias vertical_align_opts "Top" | "Middle" | "Bottom"
----@alias horizontal_align_opts "Left" | "Center" | "Right"
----@alias object_fit_opts "Contain" | "Cover" | "Fill" | "None" | "ScaleDown"
-
--- }}}
 
 ---a directory object in directories passed in setup()
 ---@class BagmanDirtyDir
+---@field horizontal_align? HorizontalAlign
+---@field hsb? Hsb valid values for its fields are from 0.0 to above
+---@field object_fit? ObjectFit
+---@field opacity? f32 from 0.0 to 1.0
 ---@field path string
----@field vertical_align? vertical_align_opts
----@field horizontal_align? horizontal_align_opts
----@field object_fit? object_fit_opts
+---@field vertical_align? VerticalAlign
 
 ---An [BagmanDirtyDir] cleaned by setup()
 ---@class BagmanCleanDir config with assigned defaults
+---@field horizontal_align HorizontalAlign
+---@field hsb Hsb valid values for its fields are from 0.0 to above
+---@field object_fit ObjectFit
+---@field opacity f32 from 0.0 to 1.0
 ---@field path string
----@field vertical_align vertical_align_opts
----@field horizontal_align horizontal_align_opts
----@field object_fit object_fit_opts
+---@field vertical_align VerticalAlign
 
 ---an image file object in images passed in setup()
 ---@class BagmanDirtyImage
+---@field horizontal_align? HorizontalAlign
+---@field hsb? Hsb valid values for its fields are from 0.0 to above
+---@field object_fit? ObjectFit
+---@field opacity? f32 from 0.0 to 1.0
 ---@field path string
----@field vertical_align? vertical_align_opts
----@field horizontal_align? horizontal_align_opts
----@field object_fit? object_fit_opts
+---@field vertical_align? VerticalAlign
 
 ---An [BagmanDirtyImage] cleaned by setup()
 ---@class BagmanCleanImage config with assigned defaults
+---@field horizontal_align HorizontalAlign
+---@field hsb Hsb valid values for its fields are from 0.0 to above
+---@field object_fit ObjectFit
+---@field opacity f32 from 0.0 to 1.0
 ---@field path string
----@field vertical_align vertical_align_opts
----@field horizontal_align horizontal_align_opts
----@field object_fit object_fit_opts
+---@field vertical_align VerticalAlign
 
 ---Holds the local config and state of BGChanger
 ---@class BagmanData
@@ -64,21 +72,25 @@
 ---Holds the local state needed to determine whether to stop because of error
 ---or because of user input, keep looping, etc.
 ---@class BagmanState
----@field is_looping boolean
----@field retries number
+---@field auto_cycle boolean
 ---@field current_image BagmanCurrentImage
+---@field retries number
 
 ---@class BagmanCurrentImage
----@field path string
----@field vertical_align vertical_align_opts
----@field horizontal_align horizontal_align_opts
----@field object_fit object_fit_opts
----@field width number
 ---@field height number
+---@field horizontal_align HorizontalAlign
+---@field hsb Hsb valid values for its fields are from 0.0 to above
+---@field object_fit ObjectFit
+---@field opacity f32 from 0.0 to 1.0
+---@field path string
+---@field vertical_align VerticalAlign
+---@field width number
 
 ---@class BagmanSetImageOptions
----@field vertical_align? vertical_align_opts
----@field horizontal_align? horizontal_align_opts
----@field object_fit? object_fit_opts
----@field width? number
----@field height? number
+---@field height number
+---@field horizontal_align HorizontalAlign
+---@field hsb Hsb valid values for its fields are from 0.0 to above
+---@field object_fit ObjectFit
+---@field opacity f32 from 0.0 to 1.0
+---@field vertical_align VerticalAlign
+---@field width number

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -20,33 +20,41 @@
 ---@field backdrop HexColor | AnsiColor
 ---@field change_tab_colors boolean whether to change tab bar colors based on the current background
 
+-- GENERAL OPTIONS {{{
+
+---@alias vertical_align_opts "Top" | "Middle" | "Bottom"
+---@alias horizontal_align_opts "Left" | "Center" | "Right"
+---@alias object_fit_opts "Contain" | "Cover" | "Fill" | "None" | "ScaleDown"
+
+-- }}}
+
 ---a directory object in directories passed in setup()
 ---@class BagmanDirtyDir
 ---@field path string
----@field vertical_align? "Top" | "Middle" | "Bottom"
----@field horizontal_align? "Left" | "Center" | "Right"
----@field object_fit? "Contain" | "Cover" | "Fill"
+---@field vertical_align? vertical_align_opts
+---@field horizontal_align? horizontal_align_opts
+---@field object_fit? object_fit_opts
 
 ---An [BagmanDirtyDir] cleaned by setup()
 ---@class BagmanCleanDir config with assigned defaults
 ---@field path string
----@field vertical_align "Top" | "Middle" | "Bottom"
----@field horizontal_align "Left" | "Center" | "Right"
----@field object_fit "Contain" | "Cover" | "Fill"
+---@field vertical_align vertical_align_opts
+---@field horizontal_align horizontal_align_opts
+---@field object_fit object_fit_opts
 
 ---an image file object in images passed in setup()
 ---@class BagmanDirtyImage
 ---@field path string
----@field vertical_align? "Top" | "Middle" | "Bottom"
----@field horizontal_align? "Left" | "Center" | "Right"
----@field object_fit? "Contain" | "Cover" | "Fill"
+---@field vertical_align? vertical_align_opts
+---@field horizontal_align? horizontal_align_opts
+---@field object_fit? object_fit_opts
 
 ---An [BagmanDirtyImage] cleaned by setup()
 ---@class BagmanCleanImage config with assigned defaults
 ---@field path string
----@field vertical_align "Top" | "Middle" | "Bottom"
----@field horizontal_align "Left" | "Center" | "Right"
----@field object_fit "Contain" | "Cover" | "Fill"
+---@field vertical_align vertical_align_opts
+---@field horizontal_align horizontal_align_opts
+---@field object_fit object_fit_opts
 
 ---Holds the local config and state of BGChanger
 ---@class BagmanData
@@ -58,10 +66,19 @@
 ---@class BagmanState
 ---@field is_looping boolean
 ---@field retries number
+---@field current_image BagmanCurrentImage
+
+---@class BagmanCurrentImage
+---@field path string
+---@field vertical_align vertical_align_opts
+---@field horizontal_align horizontal_align_opts
+---@field object_fit object_fit_opts
+---@field width number
+---@field height number
 
 ---@class BagmanSetImageOptions
----@field vertical_align? "Top" | "Middle" | "Bottom"
----@field horizontal_align? "Left" | "Center" | "Right"
----@field object_fit? "Contain" | "Cover" | "Fill"
+---@field vertical_align? vertical_align_opts
+---@field horizontal_align? horizontal_align_opts
+---@field object_fit? object_fit_opts
 ---@field width? number
 ---@field height? number

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -35,6 +35,7 @@
 ---@field object_fit? ObjectFit
 ---@field opacity? f32 from 0.0 to 1.0
 ---@field path string
+---@field scale? f32
 ---@field vertical_align? VerticalAlign
 
 ---An [BagmanDirtyDir] cleaned by setup()
@@ -44,6 +45,7 @@
 ---@field object_fit ObjectFit
 ---@field opacity f32 from 0.0 to 1.0
 ---@field path string
+---@field scale f32
 ---@field vertical_align VerticalAlign
 
 ---an image file object in images passed in setup()
@@ -53,6 +55,7 @@
 ---@field object_fit? ObjectFit
 ---@field opacity? f32 from 0.0 to 1.0
 ---@field path string
+---@field scale? f32
 ---@field vertical_align? VerticalAlign
 
 ---An [BagmanDirtyImage] cleaned by setup()
@@ -62,6 +65,7 @@
 ---@field object_fit ObjectFit
 ---@field opacity f32 from 0.0 to 1.0
 ---@field path string
+---@field scale f32
 ---@field vertical_align VerticalAlign
 
 ---Holds the local config and state of BGChanger
@@ -83,6 +87,7 @@
 ---@field object_fit ObjectFit
 ---@field opacity f32 from 0.0 to 1.0
 ---@field path string
+---@field scale f32
 ---@field vertical_align VerticalAlign
 ---@field width number
 
@@ -92,5 +97,6 @@
 ---@field hsb Hsb valid values for its fields are from 0.0 to above
 ---@field object_fit ObjectFit
 ---@field opacity f32 from 0.0 to 1.0
+---@field scale f32
 ---@field vertical_align VerticalAlign
 ---@field width number

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -6,7 +6,7 @@
 ---@field images table<number, BagmanDirtyImage | string> list of image files
 ---@field interval? number interval in seconds for changing the background
 ---@field backdrop? HexColor | AnsiColor bottom layer color to tint the image on top of it
----@field loop_on_startup? boolean whether to immediately start changing background every interval
+---@field auto_cycle? boolean whether to immediately start changing background every interval
 ---seconds on startup
 ---@field change_tab_colors? boolean whether to change tab bar colors based on the current background
 ---image


### PR DESCRIPTION
closes #14 
closes #13 

---

# New
1. `None` and `ScaleDown` for `object_fit`
    - `None` does not scale the image at all
    - `ScaleDown`  does a `Contain` scaling if the image is larger than the window. Otherwise, it will act like `None`
2. add `opacity` and `hsb` options for entries in `dirs` and `images` setup option
    - these behave the same way as wezterm's `opacity` and `hsb`
3. add `scale` option for entries in `dirs` and `images` setup option
    - adds additional scaling to the image on top of the `object_fit` setup option. This applies its scaling after `object_fit` scaled the image.
4. add documentation for `current_image()`
# Changes
1. fix direct proportion formula for computing `Contain` and `Cover` scaling. This makes it less error prone since there are no if else branches in scaling. All scenarios are handled by the simplification
2. rename setup option `loop_on_startup` to `auto_cycle`

# Examples
- `object_fit = Contain` with `scale = 0.5`
![image](https://github.com/user-attachments/assets/c71f5243-5e1a-49f1-9163-41252d634d8d)
- `object_fit = Cover` with `scale = 0.1`
![image](https://github.com/user-attachments/assets/bb311168-1cd3-4aea-80f7-9f88fb1f942c)
- `object_fit = Contain` with `scale = 1.5` and `horizontal_align = "Center"
![image](https://github.com/user-attachments/assets/fc88ebf4-e157-41a4-8e55-562b4d9e1352)
- `hue = 0.0` vs `hue = 1.0`

| `0.0` | `1.0` |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ee11d35b-d3a4-4107-8ffd-e33d087e1eb7) | ![image](https://github.com/user-attachments/assets/8096dda7-d5ca-466b-942b-df09d9374cb7) |
