### PR TITLE
Feat/experimental wezterm contain fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ bagman.setup({
                 brightness = 1.0, -- default: 1.0
             }, 
             object_fit = "Fill", -- default: "Contain"
-            scale = 0.5, -- default: 1.0
         },
 
         -- all fields except path are optional.
@@ -154,15 +153,10 @@ Fields:
     - same as wezterm's
 6. `path`
     - absolute path to image file
-7. `scale`
-    - scale multiplier applied to image after the scaling done by `object_fit`.
-    For example, `object_fit = "Contain", scale = 0.5` will first scale the
-    image to fit within the window, then scale it down to 50% of that.
-    - valid values: from `0.0` above
-8. `vertical_align`
+7. `vertical_align`
     - valid values: `"Top"`, `"Middle"`, `"Bottom"`
     - same as wezterm's
-9. `width`
+8. `width`
     - width of the image in px
 
 ### `bagman.action.next_image()`

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ local config = wezterm.config_builder()
 
 bagman.setup({
     dirs = {
-        "/abs/path/to/dir",
+        "/path/to/dir-1",
         {
-            path = os.getenv("HOME") .. "/path/to/home/subdir",
+            path = wezterm.home_dir .. "/path/to/dir-2",
             object_fit = "Contain",
             horizontal_align = "Right",
         },
@@ -57,8 +57,8 @@ return config
 bagman only registers event listeners so `bagman.apply_to_config(config)` does
 nothing for now.
 ### `bagman.setup(opts)`
-To see all possible values for the fields of `dirs` and `images` entries,
-please see the [current_image](#bagmancurrent_image) section.
+To see descriptions for the fields of `dirs` and `images` entries, please see
+the [current_image](#bagmancurrent_image) section.
 ```lua
 bagman.setup({
     -- pass in directories that contain images for bagman to search in
@@ -69,7 +69,7 @@ bagman.setup({
         -- or you can pass it in as a table where you can define options for
         -- images under that directory. Here are all the available options:
         {
-            path = os.getenv("HOME") .. "/path/to/home/subdir",
+            path = wezterm.home_dir .. "/path/to/home/subdir",
             vertical_align = "Top", -- default: "Middle"
             horizontal_align = "Right", -- default: "Center"
             opacity = 0.1, -- default: 1.0
@@ -84,7 +84,7 @@ bagman.setup({
         -- all fields except path are optional.
         -- below is equivalent to just passing it in as a string.
         {
-            path = os.getenv("HOME") .. "/path/to/another/home/subdir",
+            path = wezterm.home_dir .. "/path/to/another/home/subdir",
         },
     },
     -- you can also pass in image files
@@ -94,14 +94,14 @@ bagman.setup({
 
         -- as a table with some options
         {
-            path = os.getenv("HOME") .. "/path/to/another/image.jpg",
+            path = wezterm.home_dir .. "/path/to/another/image.jpg",
             vertical_align = "Bottom", -- default: "Middle"
             object_fit = "ScaleDown", -- default: "Contain"
         },
 
         -- as a table without the options
         {
-            path = os.getenv("HOME") .. "/path/to/another/image.gif",
+            path = wezterm.home_dir .. "/path/to/another/image.gif",
         },
     },
 

--- a/plugin/bagman/colorscheme-builder.lua
+++ b/plugin/bagman/colorscheme-builder.lua
@@ -41,15 +41,8 @@ end
 ---@param image string | { path: string, speed: number } path to image file
 ---@return TabBar color_scheme tab bar color scheme
 function M.build_tab_bar_colorscheme_from_image(image)
-	local image_path = function()
-		if type(image) == "table" then
-			return image.path
-		else
-			return image --[[@as string]]
-		end
-	end
 	---@type table<number, Color>
-	local color_from_image = wezterm.color.extract_colors_from_image(image_path(), {
+	local color_from_image = wezterm.color.extract_colors_from_image(image.path or image, {
 		-- only need 4 for tab_bar config. might add more if this is expanded (probably not)
 		num_colors = 4,
 		-- has good enough results from my testing

--- a/plugin/bagman/image-resizer.lua
+++ b/plugin/bagman/image-resizer.lua
@@ -1,37 +1,90 @@
 local wezterm = require("wezterm") --[[@as Wezterm]]
+local image_size = require("bagman.image-size") --[[@as ImageSize]]
 
 ---@class ImageResizer
 local M = {}
 
----Returns the resized dimensions of an image based on the specified object_fit strategy
----@param image_width number
----@param image_height number
+-- Returns the resized dimensions of an image based on the specified object_fit
+---@param image string path to image file
 ---@param window_width number
 ---@param window_height number
 ---@param object_fit ObjectFit
----@return number new_width
----@return number new_height
-function M.resize(image_width, image_height, window_width, window_height, object_fit)
+---@param __experimental_contain_fix_wezterm_build boolean whether the wezterm
+-- you are using is built using the contain fix pr I did
+-- [here](https://github.com/wez/wezterm/pull/6554)
+---@return { original: ImageDimensions, scaled: ImageDimensions }? dims original and scaled image dimensions
+function M.resize(image, window_width, window_height, object_fit, __experimental_contain_fix_wezterm_build)
+	if __experimental_contain_fix_wezterm_build then
+		return M.resize_v2(image, window_width, window_height, object_fit)
+	end
+
+	local image_dims = image_size.size(image)
+	if image_dims.err then
+		wezterm.log_error("BAGMAN IMAGE HANDLER ERROR:", image_dims.err)
+		return nil
+	end
+
+	---@type ImageDimensions
+	local scaled_dims
 	if "Contain" == object_fit then
-		local new_width, new_height = M.contain_dimensions(image_width, image_height, window_width, window_height)
-		return new_width, new_height
+		scaled_dims = M.contain_dimensions(image_dims.width, image_dims.height, window_width, window_height)
 	elseif "Cover" == object_fit then
-		local new_width, new_height = M.cover_dimensions(image_width, image_height, window_width, window_height)
-		return new_width, new_height
+		scaled_dims = M.cover_dimensions(image_dims.width, image_dims.height, window_width, window_height)
 	elseif "Fill" == object_fit then
-		return window_width, window_height
+		scaled_dims = { width = window_width, height = window_height }
 	elseif "None" == object_fit then
-		return image_width, image_height
+		scaled_dims = image_dims
 	elseif "ScaleDown" == object_fit then
-		if image_width > window_width or image_height > window_height then
-			local new_width, new_height = M.contain_dimensions(image_width, image_height, window_width, window_height)
-			return new_width, new_height
+		if image_dims.width > window_width or image_dims.height > window_height then
+			scaled_dims = M.contain_dimensions(image_dims.width, image_dims.height, window_width, window_height)
 		else
-			return image_width, image_height
+			scaled_dims = image_dims
 		end
 	else
 		wezterm.log_error("BAGMAN IMAGE HANDLER ERROR: unknown object_fit:", object_fit)
-		return image_width, image_height
+	end
+
+	return { original = image_dims, scaled = scaled_dims }
+end
+
+-- WARN: EXPERIMENTAL
+-- Returns the resized dimensions of an image based on the specified object_fit
+-- Skip computation for "Contain", "Cover", and "Fill"
+---@param image string path to image file
+---@param window_width number
+---@param window_height number
+---@param object_fit ObjectFit
+---@return { original: ImageDimensions, scaled: ImageDimensions }? dims original and scaled image dimensions
+function M.resize_v2(image, window_width, window_height, object_fit)
+	if "Contain" == object_fit or "Cover" == object_fit then
+		local dims = { width = object_fit, height = object_fit }
+		return { original = dims, scaled = dims }
+	elseif "Fill" == object_fit then
+		local dims = { width = "100%", height = "100%" }
+		return { original = dims, scaled = dims }
+	elseif "None" == object_fit then
+		local image_dims = image_size.size(image)
+		if image_dims.err then
+			wezterm.log_error("BAGMAN IMAGE HANDLER ERROR:", image_dims.err)
+			return nil
+		end
+		return { original = image_dims, scaled = image_dims }
+	elseif "ScaleDown" == object_fit then
+		local image_dims = image_size.size(image)
+		if image_dims.err then
+			wezterm.log_error("BAGMAN IMAGE HANDLER ERROR:", image_dims.err)
+			return nil
+		end
+		local scaled_dims
+		if image_dims.width > window_width or image_dims.height > window_height then
+			scaled_dims = M.contain_dimensions(image_dims.width, image_dims.height, window_width, window_height)
+		else
+			scaled_dims = image_dims
+		end
+		return { original = image_dims, scaled = scaled_dims }
+	else
+		wezterm.log_error("BAGMAN IMAGE HANDLER ERROR: unknown object_fit:", object_fit)
+		return nil
 	end
 end
 
@@ -43,13 +96,12 @@ end
 ---@param image_height number
 ---@param window_width number
 ---@param window_height number
----@return number width
----@return number height
+---@return ImageDimensions dims
 function M.contain_dimensions(image_width, image_height, window_width, window_height)
 	local scale_width = window_width / image_width
 	local scale_height = window_height / image_height
 	local scale = math.min(scale_width, scale_height)
-	return math.floor(image_width * scale), math.floor(image_height * scale)
+	return { width = math.floor(image_width * scale), height = math.floor(image_height * scale) }
 end
 
 ---Computes css's `object-fit: cover` width and height of an image using current window width and
@@ -61,13 +113,12 @@ end
 ---@param image_height number
 ---@param window_width number
 ---@param window_height number
----@return number width
----@return number height
+---@return ImageDimensions dims
 function M.cover_dimensions(image_width, image_height, window_width, window_height)
 	local scale_width = window_width / image_width
 	local scale_height = window_height / image_height
 	local scale = math.max(scale_width, scale_height)
-	return math.floor(image_width * scale), math.floor(image_height * scale)
+	return { width = math.floor(image_width * scale), height = math.floor(image_height * scale) }
 end
 
 return M

--- a/plugin/bagman/init.lua
+++ b/plugin/bagman/init.lua
@@ -1,10 +1,13 @@
 local wezterm = require("wezterm") --[[@as Wezterm]]
-local image_size = require("bagman.image-size") --[[@as ImageSize]]
 local image_resizer = require("bagman.image-resizer") --[[@as ImageResizer]]
 local colorscheme_builder = require("bagman.colorscheme-builder") --[[@as ColorSchemeBuilder]]
+local utils = require("bagman.utils") --[[@as BagmanUtils]]
 
 ---@class Bagman
 local M = {}
+
+---@type BagmanWeztermGlobal
+wezterm.GLOBAL.bagman = wezterm.GLOBAL.bagman or {}
 
 -- OPTION DEFAULTS {{{
 -- defaults for various bagman data
@@ -50,19 +53,6 @@ local bagman_data = {
 		-- encountered. Should only be incremented and reset in the 'bagman.next-image' event
 		-- handler.
 		retries = 0,
-		-- current background image set by bagman. Only really used when resizing window since I
-		-- need to know what object fit an image has.
-		current_image = {
-			height = 0,
-			horizontal_align = default.horizontal_align,
-			hsb = default.hsb,
-			object_fit = default.object_fit,
-			opacity = default.opacity,
-			path = "",
-			scale = default.scale,
-			vertical_align = default.vertical_align,
-			width = 0,
-		},
 	},
 }
 
@@ -234,16 +224,15 @@ local function set_bg_image(
 	}
 	window:set_config_overrides(overrides)
 
-	bagman_data.state.current_image = {
-		height = image_height,
-		horizontal_align = horizontal_align,
-		hsb = hsb,
-		object_fit = object_fit,
-		opacity = opacity,
-		path = image,
-		scale = scale,
-		vertical_align = vertical_align,
-		width = image_width,
+	wezterm.GLOBAL.bagman.current_image = {
+		height = dims.original.height,
+		horizontal_align = image.horizontal_align,
+		hsb = image.hsb,
+		object_fit = image.object_fit,
+		opacity = image.opacity,
+		path = image.path,
+		vertical_align = image.vertical_align,
+		width = dims.original.width,
 	}
 end
 
@@ -365,8 +354,9 @@ end
 
 -- current background image set by bagman. changing this won't do anything and
 -- is only for reading purposes.
+---@return BagmanCurrentImage
 function M.current_image()
-	return require("bagman.utils").table.shallow_copy(bagman_data.state.current_image)
+	return utils.table.deep_copy(wezterm.GLOBAL.bagman.current_image)
 end
 
 -- Helper for ze autocomplete. Contains emitters equivalent to:

--- a/plugin/bagman/utils.lua
+++ b/plugin/bagman/utils.lua
@@ -1,9 +1,11 @@
+---@class BagmanUtils
 local M = {}
 -- additional table methods
 M.table = {}
 
 -- returns a shallow copy of a table. this means table values will still be
 -- by reference.
+-- used for tables containing atomic types
 ---@param tbl table
 ---@return table tbl_copy
 function M.table.shallow_copy(tbl)
@@ -12,6 +14,29 @@ function M.table.shallow_copy(tbl)
 		tbl_copy[k] = v
 	end
 	return tbl_copy
+end
+
+-- returns a deep copy of a table.
+-- used for when tables contain other tables.
+-- credits: https://gist.github.com/tylerneylon/81333721109155b2d244
+---@param tbl table
+---@param seen? table whether we saw this table before, to avoid inf recursion
+---@return table tbl_copy
+function M.table.deep_copy(tbl, seen)
+	if type(tbl) ~= "table" then
+		return tbl
+	end
+	if seen and seen[tbl] then
+		return seen[tbl]
+	end
+
+	local s = seen or {}
+	local res = {}
+	s[tbl] = res
+	for k, v in pairs(tbl) do
+		res[M.table.deep_copy(k, s)] = M.table.deep_copy(v, s)
+	end
+	return setmetatable(res, getmetatable(tbl))
 end
 
 return M

--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -10,95 +10,154 @@
 
 -- }}}
 
+-- IMAGE METADATA {{{
+
+---@class ImageDimensions
+---@field width number | string | ObjectFit
+---@field height number | string | ObjectFit
+
+-- }}}
+
+-- BAGMAN API {{{
+
 ---Config from user passed to setup()
 ---@class BagmanSetupOptions
----@field auto_cycle? boolean whether to immediately start changing background every interval
----seconds on startup
+-- whether to immediately start changing background every interval
+-- seconds on startup
+---@field auto_cycle? boolean
 ---@field backdrop? Backdrop | HexColor | AnsiColor
----@field dirs table<number, BagmanDirtyDir | string> list of directories that contain images
----@field change_tab_colors? boolean whether to change tab bar colors based on the current background
----image
----@field images table<number, BagmanDirtyImage | string> list of image files
----@field interval? number interval in seconds for changing the background
+-- list of directories that contain images
+---@field dirs table<number, BagmanDirtyDir | string>
+-- whether to change tab bar colors based on the current background
+-- image
+---@field change_tab_colors? boolean
+---@field experimental BagmanExperimental
+-- list of image files
+---@field images table<number, BagmanDirtyImage | string> interval in seconds for changing the background
+---@field interval? number
 
----A [BagmanSetupOptions] with optional values filled in with defaults.
----Holds the local config needed to determine how to change the background
----@class BagmanConfig
----@field backdrop Backdrop
----@field change_tab_colors boolean whether to change tab bar colors based on the current background
----@field dirs table<number, BagmanCleanDir>
----@field images table<number, BagmanCleanImage>
----@field interval number
+-- experimental setup option. be warned when using as these might change at any
+-- time
+---@class BagmanExperimental
+-- whether the wezterm you are using is built using my branch at
+-- https://github.com/saltkid/wezterm/tree/fix/contain-tall-images
+---@field contain_fix_wezterm_build bool
 
----a directory object in directories passed in setup()
----@class BagmanDirtyDir
+-- args passed to bagman.emit.set_image(window, path/to/image, { ... })
+---@class BagmanSetImageOptions
+---@field height? number
 ---@field horizontal_align? HorizontalAlign
----@field hsb? Hsb valid values for its fields are from 0.0 to above
+-- valid values for its fields are from 0.0 to above
+---@field hsb? Hsb
 ---@field object_fit? ObjectFit
----@field opacity? f32 from 0.0 to 1.0
----@field path string
----@field scale? f32
+-- from 0.0 above
+---@field opacity? f32
 ---@field vertical_align? VerticalAlign
+---@field width? number
 
----An [BagmanDirtyDir] cleaned by setup()
----@class BagmanCleanDir config with assigned defaults
----@field horizontal_align HorizontalAlign
----@field hsb Hsb valid values for its fields are from 0.0 to above
----@field object_fit ObjectFit
----@field opacity f32 from 0.0 to 1.0
----@field path string
----@field scale f32
----@field vertical_align VerticalAlign
+-- }}}
 
----an image file object in images passed in setup()
----@class BagmanDirtyImage
----@field horizontal_align? HorizontalAlign
----@field hsb? Hsb valid values for its fields are from 0.0 to above
----@field object_fit? ObjectFit
----@field opacity? f32 from 0.0 to 1.0
----@field path string
----@field scale? f32
----@field vertical_align? VerticalAlign
-
----An [BagmanDirtyImage] cleaned by setup()
----@class BagmanCleanImage config with assigned defaults
----@field horizontal_align HorizontalAlign
----@field hsb Hsb valid values for its fields are from 0.0 to above
----@field object_fit ObjectFit
----@field opacity f32 from 0.0 to 1.0
----@field path string
----@field scale f32
----@field vertical_align VerticalAlign
+-- BAGMAN LOCAL STATE {{{
 
 ---Holds the local config and state of BGChanger
 ---@class BagmanData
 ---@field config BagmanConfig
 ---@field state BagmanState
 
----Holds the local state needed to determine whether to stop because of error
----or because of user input, keep looping, etc.
+-- These are the possible fields in wezterm.GLOBAL.bagman
+-- Since these are used for bagman functionality, please don't arbitrarily
+-- change these.
+---@class BagmanWeztermGlobal
+-- stores the latest image set by bagman. Used for knowing what object_fit an
+-- image has when resizing. Also used for determining whether an image cycle
+-- has already started on startup.
+---@field current_image BagmanCurrentImage
+-- user triggered `stop_loop()` (false) and `start_loop()` (true)
+---@field manually_cycle boolean
+
+-- A [BagmanSetupOptions] with optional values filled in with defaults.
+-- Holds the local config needed to determine how to change the background.
+-- should be READONLY and never changed after initial setup.
+---@class BagmanConfig
+---@field backdrop Backdrop
+-- whether to change tab bar colors based on the current background
+---@field change_tab_colors boolean
+---@field dirs table<number, BagmanCleanDir>
+---@field __experimental BagmanExperimental
+---@field images table<number, BagmanCleanImage>
+---@field interval number
+
+-- Holds the local state needed to determine whether to stop because of error
+-- or because of user input, keep looping, etc. MUTABLE
 ---@class BagmanState
 ---@field auto_cycle boolean
----@field current_image BagmanCurrentImage
 ---@field retries number
 
----@class BagmanCurrentImage
----@field height number
----@field horizontal_align HorizontalAlign
----@field hsb Hsb valid values for its fields are from 0.0 to above
----@field object_fit ObjectFit
----@field opacity f32 from 0.0 to 1.0
----@field path string
----@field scale f32
----@field vertical_align VerticalAlign
----@field width number
+-- }}}
 
----@class BagmanSetImageOptions
----@field height number
+-- BAGMAN DIRECTORY AND IMAGE OBJECTS FROM SETUP {{{
+
+-- a directory object in directories passed in setup()
+---@class BagmanDirtyDir
+---@field horizontal_align? HorizontalAlign
+-- valid values for its fields are from 0.0 to above
+---@field hsb? Hsb
+---@field object_fit? ObjectFit
+-- from 0.0 to 1.0
+---@field opacity? f32
+---@field path string
+---@field vertical_align? VerticalAlign
+
+-- An [BagmanDirtyDir] cleaned by setup()
+-- config with assigned defaults
+---@class BagmanCleanDir
 ---@field horizontal_align HorizontalAlign
----@field hsb Hsb valid values for its fields are from 0.0 to above
+-- valid values for its fields are from 0.0 to above
+---@field hsb Hsb
 ---@field object_fit ObjectFit
----@field opacity f32 from 0.0 to 1.0
----@field scale f32
+-- from 0.0 above
+---@field opacity f32
+---@field path string
 ---@field vertical_align VerticalAlign
----@field width number
+
+-- an image file object in images passed in setup()
+---@class BagmanDirtyImage
+---@field horizontal_align? HorizontalAlign
+-- valid values for its fields are from 0.0 to above
+---@field hsb? Hsb
+---@field object_fit? ObjectFit
+-- from 0.0 to 1.0
+---@field opacity? f32
+---@field path string
+---@field vertical_align? VerticalAlign
+
+---An [BagmanDirtyImage] cleaned by setup()
+---@class BagmanCleanImage config with assigned defaults
+---@field horizontal_align HorizontalAlign
+-- valid values for its fields are from 0.0 to above
+---@field hsb Hsb
+---@field object_fit ObjectFit
+-- from 0.0 above
+---@field opacity f32
+---@field path string
+---@field vertical_align VerticalAlign
+
+-- }}}
+
+-- BAGMAN CURRENT IMAGE OBJECT {{{
+
+-- current background image set by bagman. Only really used when resizing window since I
+-- need to know what object fit an image has.
+---@class BagmanCurrentImage
+---@field height number | string | ObjectFit scaled width. can be in px, "n%", or any of the ObjectFit values
+---@field horizontal_align HorizontalAlign
+-- valid values for its fields are from 0.0 to above
+---@field hsb Hsb
+---@field object_fit ObjectFit
+-- from 0.0 above
+---@field opacity f32
+---@field path string
+---@field vertical_align VerticalAlign
+---@field width number | string | ObjectFit scaled width. can be in px, "n%", or any of the ObjectFit values
+
+-- }}}


### PR DESCRIPTION
closes #19, closes #18, closes #17, closes #4 

**BIG PR**, these issues are all coupled to each other (at least the way I did it) so excuse the big PR

---

# New
1. `utils` module now has a `table.deep_copy()` for tables that contain tables
2. new unstable `experimental` setup option to support my `Contain` fix until it gets merged to wezterm. options under here can change at anytime and is really only documented in `types.lua`

# Changes
1. image cycling logic is now partial config reload resistant. an example of a partial config reload is when saving an edit to your config file. 
    - This means that if there are partial reloads, the current image cycle will continue without adding more cycles. If there are full reloads, bagman will start a new image cycle as expected.
2. due to change above, bagman 2 bagman states (`manually_cycle` and `current_image`) are in `wezterm.GLOBAL` to persist through partial and full config reloads. 
    - didn't want to do this before since it exposes internal logic to the public, which might lead to accidental changes to it, domino effecting bagman's processes, but I see no other way to persist through partial config reloads.
3. Removed `scale` option due to me moving away from manually computing px values for `Contain`, `Cover` and `Fill`.
4. use objects instead of multiple returns.