### PR TITLE
Fix/overlapping image change

### DIFF
--- a/plugin/types.lua
+++ b/plugin/types.lua
@@ -101,6 +101,9 @@
 ---@class BagmanState
 -- amount of `next-image` retries. max of 5 till bagman stops trying
 ---@field retries number
+-- currently set colorscheme by user (thru wezterm config) or bagman (thru
+-- changing image)
+---@field current_colorscheme Palette?
 
 -- }}}
 


### PR DESCRIPTION
## New
- Global state to track image cycles, to ensure only one cycle exists.
## Changes
- Changing image no longer overrides user set colorscheme to its defaults
  - now only changes TabBar colors if `change_tab_colors` setup option is set to `true`